### PR TITLE
JOY-4 fix: styles; update component

### DIFF
--- a/src/shared/ui/RadioGroup/RadioGroup.module.scss
+++ b/src/shared/ui/RadioGroup/RadioGroup.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  position: relative;
 }
 
 .root {
@@ -9,10 +10,10 @@
   flex-wrap: wrap;
   gap: 12px;
   cursor: pointer;
+  position: relative;
 
   &[data-disabled] {
     cursor: default;
-    opacity: 0.5;
   }
 }
 
@@ -37,6 +38,7 @@
 
     [data-disabled] & {
       cursor: default;
+      opacity: 0.5;
     }
   }
 }
@@ -47,12 +49,11 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  width: 20px;
-  height: 20px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   transition: 200ms all;
   background-color: transparent;
-  margin: 3px;
 
   &::before {
     content: "";
@@ -94,10 +95,7 @@
   }
 
   .option:hover:not([data-disabled]) & {
-    background-color: var(--color-dark-300);
-    width: 26px;
-    height: 26px;
-    margin: 0;
+    background-color: var(--color-dark-100);
   }
 
   .option:focus-visible & {
@@ -110,16 +108,16 @@
 
   .option:active:not([data-disabled]) & {
     background-color: var(--color-dark-100);
-    width: 26px;
-    height: 26px;
-    margin: 0;
   }
 
   .root[data-disabled] & {
-    opacity: 0.5;
-
     &::before {
-      border-color: var(--color-dark-100);
+      border-color: var(--color-dark-300);
+      border-width: 2px;
+    }
+
+    &::after {
+      background-color: var(--color-dark-300);
     }
   }
 }

--- a/src/shared/ui/RadioGroup/RadioGroup.tsx
+++ b/src/shared/ui/RadioGroup/RadioGroup.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
+import { forwardRef, ComponentPropsWithoutRef, ComponentRef } from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { clsx } from "clsx";
 
 import s from "./RadioGroup.module.scss";
 
-const RadioGroupRoot = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+const RadioGroupRoot = forwardRef<
+  ComponentRef<typeof RadioGroupPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
 >(({ className, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Root
@@ -19,9 +19,9 @@ const RadioGroupRoot = React.forwardRef<
 
 RadioGroupRoot.displayName = RadioGroupPrimitive.Root.displayName;
 
-const RadioGroupItem = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+const RadioGroupItem = forwardRef<
+  ComponentRef<typeof RadioGroupPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
 >(({ className, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Item
@@ -44,13 +44,10 @@ type Option = {
 export type RadioGroupProps = {
   errorMessage?: string;
   options: Option[];
-} & Omit<
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
-  "children"
->;
+} & Omit<ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>, "children">;
 
-const RadioGroup = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+const RadioGroup = forwardRef<
+  ComponentRef<typeof RadioGroupPrimitive.Root>,
   RadioGroupProps
 >((props, ref) => {
   const { errorMessage, options, ...restProps } = props;


### PR DESCRIPTION
JOY-4: Fix RadioGroup Styles

- Исправление проблемы смещения элементов и корректное отображение в disabled состоянии
- Обновлен компонент: заменен устаревший `ElementRef` на `ComponentRef`