### PR TITLE
Joy 29 add: typography

### DIFF
--- a/src/app/styles/typography.css
+++ b/src/app/styles/typography.css
@@ -16,5 +16,7 @@
 
     /*font weights*/
     --font-weight-regular: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
     --font-weight-bold: 700;
 }

--- a/src/shared/ui/typography/Typography.module.scss
+++ b/src/shared/ui/typography/Typography.module.scss
@@ -1,0 +1,135 @@
+@mixin typography(
+  $fontSize,
+  $lineHeight,
+  $fontWeight,
+  $color: var(--color-dark-900)
+) {
+  margin: 0;
+  font-size: $fontSize;
+  font-weight: $fontWeight;
+  line-height: $lineHeight;
+  font-family: var(--font-family-primary);
+  color: $color;
+}
+
+.text {
+  margin: 0;
+}
+
+.large {
+  @include typography(
+    var(--font-size-xxl),
+    var(--line-height-l),
+    var(--font-weight-semibold)
+  );
+}
+
+.h1 {
+  @include typography(
+    var(--font-size-xl),
+    var(--line-height-l),
+    var(--font-weight-bold)
+  );
+}
+
+.h2 {
+  @include typography(
+    var(--font-size-l),
+    var(--line-height-m),
+    var(--font-weight-bold)
+  );
+}
+
+.h3 {
+  @include typography(
+    var(--font-size-m),
+    var(--line-height-m),
+    var(--font-weight-semibold)
+  );
+}
+
+.body1 {
+  @include typography(
+    var(--font-size-m),
+    var(--line-height-m),
+    var(--font-weight-regular)
+  );
+}
+
+.subtitle1 {
+  @include typography(
+    var(--font-size-m),
+    var(--line-height-m),
+    var(--font-weight-bold)
+  );
+}
+
+.body2 {
+  @include typography(
+    var(--font-size-s),
+    var(--line-height-m),
+    var(--font-weight-regular)
+  );
+}
+
+.subtitle2 {
+  @include typography(
+    var(--font-size-s),
+    var(--line-height-m),
+    var(--font-weight-bold)
+  );
+}
+
+.caption {
+  @include typography(
+    var(--font-size-xs),
+    var(--line-height-s),
+    var(--font-weight-regular)
+  );
+}
+
+.caption2 {
+  @include typography(
+    var(--font-size-xs),
+    var(--line-height-s),
+    var(--font-weight-semibold)
+  );
+}
+
+.link1,
+.link1:visited {
+  @include typography(
+    var(--font-size-s),
+    var(--line-height-m),
+    var(--font-weight-regular),
+    var(--color-accent-500)
+  );
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-skip-ink: none;
+}
+
+.link2,
+.link2:visited {
+  @include typography(
+    var(--font-size-xs),
+    var(--line-height-s),
+    var(--font-weight-regular),
+    var(--color-accent-500)
+  );
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-skip-ink: none;
+}
+
+.fw-regular {
+  font-weight: var(--font-weight-regular);
+}
+
+.fw-medium {
+  font-weight: var(--font-weight-medium);
+}
+
+.fw-bold {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/shared/ui/typography/Typography.stories.tsx
+++ b/src/shared/ui/typography/Typography.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Typography } from './'
+
+const meta = {
+  argTypes: {
+    variant: {
+      control: { type: 'radio' },
+      options: [
+        'large',
+        'h1',
+        'h2',
+        'h3',
+        'body1',
+        'body2',
+        'subtitle1',
+        'subtitle2',
+        'caption',
+        'caption2',
+        'link1',
+        'link2',
+        'error',
+      ],
+    },
+    fontWeight: {
+      control: { type: 'radio' },
+      options: ['regular', 'medium', 'bold'],
+    },
+  },
+  component: Typography,
+  tags: ['autodocs'],
+  title: 'Components/Typography',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Typography>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Large: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'large',
+  },
+}
+
+export const H1: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'h1',
+  },
+}
+
+export const H2: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'h2',
+  },
+}
+
+export const H3: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'h3',
+  },
+}
+
+export const Body1Regular: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'body1',
+    fontWeight: 'regular',
+  },
+}
+
+export const Body1Bold: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'body1',
+    fontWeight: 'bold',
+  },
+}
+
+export const Body2Regular: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'body2',
+    fontWeight: 'regular',
+  },
+}
+
+export const Body2Medium: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'body2',
+    fontWeight: 'medium',
+  },
+}
+
+export const Body2Bold: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'body2',
+    fontWeight: 'bold',
+  },
+}
+
+export const Caption: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'caption',
+  },
+}
+
+export const Caption2: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'caption2',
+  },
+}
+
+export const Link1: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'link1',
+  },
+}
+
+export const Link2: Story = {
+  args: {
+    children:
+      'Carosserie Test Zürich\nStauffacherstrasse 31\n8004 Zürich, ZH, CH',
+    variant: 'link2',
+  },
+}
+
+export const FontWeightVariations: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Отображает вариации fontWeight (regular, medium, bold) для вариантов body1 и body2.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <div>
+        <Typography variant="body1" fontWeight="regular">
+          Body1 - Regular (400)
+        </Typography>
+        <Typography variant="body1" fontWeight="medium">
+          Body1 - Medium (500)
+        </Typography>
+        <Typography variant="body1" fontWeight="bold">
+          Body1 - Bold (700)
+        </Typography>
+      </div>
+
+      <div>
+        <Typography variant="body2" fontWeight="regular">
+          Body2 - Regular (400)
+        </Typography>
+        <Typography variant="body2" fontWeight="bold">
+          Body2 - Bold (700)
+        </Typography>
+      </div>
+    </div>
+  ),
+}

--- a/src/shared/ui/typography/Typography.stories.tsx
+++ b/src/shared/ui/typography/Typography.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { Typography } from './'
+import { Typography } from './Typography'
 
 const meta = {
   argTypes: {
@@ -13,13 +13,10 @@ const meta = {
         'h3',
         'body1',
         'body2',
-        'subtitle1',
-        'subtitle2',
         'caption',
         'caption2',
         'link1',
         'link2',
-        'error',
       ],
     },
     fontWeight: {

--- a/src/shared/ui/typography/Typography.tsx
+++ b/src/shared/ui/typography/Typography.tsx
@@ -17,7 +17,7 @@ export type TypographyVariant =
 
 export type FontWeight = 'regular' | 'medium' | 'bold'
 
-export interface TextProps<T extends ElementType = 'p'> {
+export interface TypographyProps<T extends ElementType = 'p'> {
   as?: T
   children?: ReactNode
   className?: string
@@ -30,18 +30,22 @@ export function Typography<T extends ElementType = 'p'>({
   className,
   variant = 'body1',
   fontWeight,
+  children,
   ...restProps
-}: Omit<ComponentPropsWithoutRef<T>, keyof TextProps<T>> & TextProps<T>) {
-  const isBody = variant === 'body1' || variant === 'body2'
+}: Omit<ComponentPropsWithoutRef<T>, keyof TypographyProps<T>> &
+  TypographyProps<T>) {
+  const Component = as || 'p'
 
   const classNames = clsx(
     s.text,
     s[variant],
-    isBody && fontWeight && s[`fw-${fontWeight}`],
+    fontWeight && variant.startsWith('body') && s[`fw-${fontWeight}`],
     className
   )
 
-  const Component = as || 'p'
-
-  return <Component className={classNames} {...restProps} />
+  return (
+    <Component className={classNames} {...restProps}>
+      {children}
+    </Component>
+  )
 }

--- a/src/shared/ui/typography/Typography.tsx
+++ b/src/shared/ui/typography/Typography.tsx
@@ -1,0 +1,47 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
+import { clsx } from 'clsx'
+
+import s from './Typography.module.scss'
+
+export type TypographyVariant =
+  | 'large'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'body1'
+  | 'body2'
+  | 'caption'
+  | 'caption2'
+  | 'link1'
+  | 'link2'
+
+export type FontWeight = 'regular' | 'medium' | 'bold'
+
+export interface TextProps<T extends ElementType = 'p'> {
+  as?: T
+  children?: ReactNode
+  className?: string
+  variant?: TypographyVariant
+  fontWeight?: FontWeight
+}
+
+export function Typography<T extends ElementType = 'p'>({
+  as,
+  className,
+  variant = 'body1',
+  fontWeight,
+  ...restProps
+}: Omit<ComponentPropsWithoutRef<T>, keyof TextProps<T>> & TextProps<T>) {
+  const isBody = variant === 'body1' || variant === 'body2'
+
+  const classNames = clsx(
+    s.text,
+    s[variant],
+    isBody && fontWeight && s[`fw-${fontWeight}`],
+    className
+  )
+
+  const Component = as || 'p'
+
+  return <Component className={classNames} {...restProps} />
+}

--- a/src/shared/ui/typography/index.ts
+++ b/src/shared/ui/typography/index.ts
@@ -1,0 +1,1 @@
+export * from './Typography'


### PR DESCRIPTION
Создан универсальный компонент Typography для отображения текстовых элементов в проекте: 

- используется семантическая разметка, поддержка различных вариантов (variant), таких как: large, h1, h2, h3, body1, body2, caption, caption2, link1, link2;
- для вариантов body1 и body2 реализована поддержка пропа fontWeight с возможными значениями: 'regular', 'medium',
'bold';
- внутри компонента корректно задаются стили для каждого варианта через условную логику (например, разные размеры шрифта, межстрочные интервалы, веса шрифта).

![typography](https://github.com/user-attachments/assets/44cb1cd4-2538-4126-ab99-214fb7ffb29f)
