### PR TITLE
feat: implement OAuth2.0 login flow with AuthProvider, getMe, and AuthGuard

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
-    "react-spinners": "^0.15.0",
     "react-toastify": "^11.0.5",
     "zod": "^3.24.2"
   },
@@ -55,7 +54,6 @@
     "@storybook/test": "8.6.4",
     "@storybook/theming": "^8.6.4",
     "@types/node": "^20.17.24",
-    "@types/nprogress": "^0.2.3",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@types/react-google-recaptcha": "^2.1.9",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import '@/app/globals.css'
 import s from './layout.module.scss'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
+import { AuthProvider } from '@/shared/providers/AuthProvider'
 
 export const metadata: Metadata = {
   title: 'Joyfy',
@@ -20,15 +21,17 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <ReduxProvider>
-          <ToastContainer
-            position="top-right"
-            autoClose={3000}
-            hideProgressBar={false}
-          />
-          <Header />
-          <main className={s.main}>
-            <div className={s.mainContainer}>{children}</div>
-          </main>
+          <AuthProvider>
+            <ToastContainer
+              position="top-right"
+              autoClose={3000}
+              hideProgressBar={false}
+            />
+            <Header />
+            <main className={s.main}>
+              <div className={s.mainContainer}>{children}</div>
+            </main>
+          </AuthProvider>
         </ReduxProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,20 +8,8 @@ import { useClearAllDataMutation } from '@/features/auth/api/authApi'
 import { useAuth } from '@/features/auth/hooks/useAuth'
 import { toast } from 'react-toastify'
 import { useState } from 'react'
-import { ClipLoader } from 'react-spinners'
+import { Loader } from '@/shared/ui/loader/Loader'
 
-const LoadingSpinner = () => (
-  <div
-    style={{
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      height: '100vh',
-    }}
-  >
-    <ClipLoader size={50} color="#2563eb" />
-  </div>
-)
 
 export default function Home() {
   const router = useRouter()
@@ -51,7 +39,7 @@ export default function Home() {
   }
 
   if (authLoading || isClearing) {
-    return <LoadingSpinner />
+    return <Loader />
   }
 
   return (

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,59 +1,12 @@
-import { useEffect, useState } from 'react'
-import {
-  useLazyGetMeQuery,
-  useRefreshTokenMutation,
-  useLogoutMutation,
-} from '../api/authApi'
-import { MeResponse } from '../api/authApi.types'
+import { AuthContext } from '@/shared/providers/AuthProvider'
+import { useContext } from 'react'
 
 export const useAuth = () => {
-  const [triggerGetMe, result] = useLazyGetMeQuery()
-  const [refreshToken] = useRefreshTokenMutation()
-  const [logout] = useLogoutMutation()
-  const [user, setUser] = useState<MeResponse | null>(null)
+  const context = useContext(AuthContext)
 
-  const isAuthenticated = !!user
-
-  useEffect(() => {
-    const fetchUserData = async () => {
-      try {
-        const userData = await triggerGetMe().unwrap()
-        setUser(userData)
-      } catch {
-        try {
-          await refreshToken().unwrap()
-          const userData = await triggerGetMe().unwrap()
-          setUser(userData)
-        } catch {
-          setUser(null)
-        }
-      }
-    }
-
-    fetchUserData()
-  }, [triggerGetMe, refreshToken])
-
-  const logoutUser = async () => {
-    try {
-      await logout().unwrap()
-    } catch (err: any) {
-      if (err?.status === 401) {
-        console.warn('Already unauthorized')
-      } else {
-        throw err
-      }
-    } finally {
-      setUser(null)
-    }
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
   }
 
-  return {
-    user,
-    isAuthenticated,
-    isLoading: result.isLoading,
-    isError: result.isError,
-    isSuccess: result.isSuccess,
-    refetch: triggerGetMe,
-    logoutUser,
-  }
+  return context
 }

--- a/src/features/auth/hooks/useOAuthLogin.ts
+++ b/src/features/auth/hooks/useOAuthLogin.ts
@@ -1,5 +1,5 @@
 import { useLazyGetMeQuery } from '@/features/auth/api/authApi'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState, useCallback } from 'react'
 import { toast } from 'react-toastify'
 
@@ -7,23 +7,57 @@ type ErrorWithData = {
   data?: {
     message?: string
   }
+  status?: number
+}
+
+const queryErrorMessages: Record<string, string> = {
+  email_exists:
+    'This email is already registered with a different method. Please use your original login method.',
+  account_not_found: 'Account not found. Please register first.',
+  unauthorized: 'Authentication failed. Please try again.',
+  unknown: 'Authentication error. Please try again later.',
 }
 
 export const useOAuthLogin = () => {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const queryError = searchParams.get('error')
   const [triggerGetMe] = useLazyGetMeQuery()
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   const extractErrorMessage = (err: unknown): string => {
+    console.error('Raw OAuth error:', err)
+
     if (typeof err === 'object' && err !== null && 'data' in err) {
       const errorData = err as ErrorWithData
-      return (
-        errorData.data?.message || 'Authentication failed. Please try again.'
-      )
+
+      if (errorData.data?.message?.includes('email already exists')) {
+        return queryErrorMessages.email_exists
+      }
+
+      if (errorData.data?.message?.includes('account not found')) {
+        return queryErrorMessages.account_not_found
+      }
+
+      if (errorData.status === 401) {
+        return queryErrorMessages.unauthorized
+      }
+
+      return errorData.data?.message || queryErrorMessages.unknown
     }
 
-    return 'Authentication failed. Please try again.'
+    if (err instanceof Error) {
+      if (
+        err.message.includes('Network') ||
+        err.message.includes('ECONNREFUSED')
+      ) {
+        return 'Connection error. Please check your internet connection and try again.'
+      }
+      return err.message
+    }
+
+    return queryErrorMessages.unknown
   }
 
   const completeAuth = useCallback(async () => {
@@ -48,8 +82,17 @@ export const useOAuthLogin = () => {
   }, [triggerGetMe, router])
 
   useEffect(() => {
+    if (queryError) {
+      const message =
+        queryErrorMessages[queryError] || queryErrorMessages.unknown
+      setError(message)
+      setIsLoading(false)
+      toast.error(message)
+      return
+    }
+
     completeAuth()
-  }, [completeAuth])
+  }, [queryError, completeAuth])
 
   return {
     isLoading,

--- a/src/features/auth/ui/authGuard/AuthGuard.tsx
+++ b/src/features/auth/ui/authGuard/AuthGuard.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { ReactNode, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+import { Typography } from '@/shared/ui'
+
+import { useAuth } from '../../hooks/useAuth'
+import { Loader } from '@/shared/ui/loader/Loader'
+import s from './authGuard.module.scss'
+
+type AuthGuardProps = {
+  children: ReactNode
+  requireAuth?: boolean
+  redirectPath?: string
+}
+
+export const AuthGuard = ({
+  children,
+  requireAuth = false,
+  redirectPath = requireAuth ? '/login' : '/',
+}: AuthGuardProps) => {
+  const { isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (
+        (requireAuth && !isAuthenticated) ||
+        (!requireAuth && isAuthenticated)
+      ) {
+        router.push(redirectPath)
+      }
+    }
+  }, [isAuthenticated, isLoading, requireAuth, redirectPath, router])
+
+  if (isLoading) {
+    return (
+      <div className={s.loadingContainer} role="status" aria-busy="true">
+        <Loader />
+        <Typography className={s.loadingText}>Loading...</Typography>
+      </div>
+    )
+  }
+
+  if ((requireAuth && !isAuthenticated) || (!requireAuth && isAuthenticated)) {
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/src/features/auth/ui/login/login.module.scss
+++ b/src/features/auth/ui/login/login.module.scss
@@ -3,6 +3,8 @@
   flex-direction: column;
   align-items: center;
   max-width: 378px;
+  width: 100%;
+  margin: 0 auto;
   padding: 23px 24px 30px;
 
   .socialLinksWrap {

--- a/src/features/auth/ui/socialLinks/SocialLinks.tsx
+++ b/src/features/auth/ui/socialLinks/SocialLinks.tsx
@@ -4,6 +4,9 @@ import { FaGithub } from 'react-icons/fa'
 import { FcGoogle } from 'react-icons/fc'
 import { Button } from '@/shared/ui'
 import { toast } from 'react-toastify'
+import { useAuth } from '../../hooks/useAuth'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
 import s from './socialLinks.module.scss'
 
 type SocialLinksProps = {
@@ -18,6 +21,26 @@ export const SocialLinks = ({
   onStartLoading,
 }: SocialLinksProps) => {
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const provider = searchParams.get('provider')
+    const error = searchParams.get('error')
+
+    if (provider && error) {
+      toast.error(`Authentication with ${provider} failed: ${error}`)
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/')
+    }
+  }, [isAuthenticated, router])
+
+  if (isAuthenticated) return null
 
   const handleSocialLogin = (
     e: React.MouseEvent<HTMLAnchorElement>,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+// Middleware placeholder — currently allows all requests
+export function middleware(request: NextRequest) {
+  // Future: Add authentication or access control logic here
+
+  return NextResponse.next()
+}
+
+// Matcher: applies middleware to all routes except for static assets and favicon
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}

--- a/src/shared/providers/AuthProvider.tsx
+++ b/src/shared/providers/AuthProvider.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import {
+  useLazyGetMeQuery,
+  useLogoutMutation,
+  useRefreshTokenMutation,
+} from '@/features/auth/api/authApi'
+import { MeResponse } from '@/features/auth/api/authApi.types'
+import React, {
+  createContext,
+  ReactNode,
+  useState,
+  useEffect,
+  useCallback,
+} from 'react'
+
+import { toast } from 'react-toastify'
+
+type AuthContextType = {
+  user: MeResponse | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  isError: boolean
+  checkAuth: () => Promise<MeResponse | null>
+  logoutUser: () => Promise<void>
+  refetchUser: () => Promise<MeResponse | null>
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [triggerGetMe, { isError }] = useLazyGetMeQuery()
+  const [refreshToken] = useRefreshTokenMutation()
+  const [logout] = useLogoutMutation()
+  const [user, setUser] = useState<MeResponse | null>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [refreshAttempted, setRefreshAttempted] = useState<boolean>(false)
+
+  const isAuthenticated = !!user
+
+  const checkAuth = useCallback(
+    async (showToast = false): Promise<MeResponse | null> => {
+      setIsLoading(true)
+
+      try {
+        const userData = await triggerGetMe().unwrap()
+        setUser(userData)
+
+        if (showToast) {
+          toast.success('Successfully authenticated')
+        }
+
+        return userData
+      } catch (error) {
+        if (!refreshAttempted) {
+          setRefreshAttempted(true)
+          try {
+            await refreshToken().unwrap()
+            try {
+              const userData = await triggerGetMe().unwrap()
+              setUser(userData)
+
+              if (showToast) {
+                toast.success('Session restored')
+              }
+
+              return userData
+            } catch (getMeError) {
+              setUser(null)
+              return null
+            }
+          } catch (refreshError) {
+            setUser(null)
+            return null
+          }
+        } else {
+          setUser(null)
+          return null
+        }
+      } finally {
+        setIsLoading(false)
+        setRefreshAttempted(false)
+      }
+    },
+    [triggerGetMe, refreshToken, refreshAttempted]
+  )
+
+  const logoutUser = async (): Promise<void> => {
+    try {
+      await logout().unwrap()
+      toast.info('Logged out successfully')
+    } catch (error: any) {
+      if (error?.status === 401) {
+        console.warn('Already unauthorized')
+      } else {
+        toast.error('Error during logout')
+        console.error('Logout error:', error)
+      }
+    } finally {
+      setUser(null)
+    }
+  }
+
+  const refetchUser = async (): Promise<MeResponse | null> => {
+    return await checkAuth(false)
+  }
+
+  useEffect(() => {
+    checkAuth()
+  }, [])
+
+  const value = {
+    user,
+    isAuthenticated,
+    isLoading,
+    isError,
+    checkAuth,
+    logoutUser,
+    refetchUser,
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/src/shared/ui/loader/Loader.module.scss
+++ b/src/shared/ui/loader/Loader.module.scss
@@ -1,0 +1,35 @@
+.fullscreen {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  gap: 12px;
+}
+
+.inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid rgba(94, 96, 206, 0.2);
+  border-top-color: var(--color-accent-500);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.message {
+  font-size: 14px;
+  color: var(--color-accent-500);
+  text-align: center;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/shared/ui/loader/Loader.tsx
+++ b/src/shared/ui/loader/Loader.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import s from './Loader.module.scss'
+
+type LoaderProps = {
+  message?: string
+  fullScreen?: boolean
+}
+
+export const Loader = ({
+  message = 'Loading...',
+  fullScreen = true,
+}: LoaderProps) => {
+  return (
+    <div
+      className={fullScreen ? s.fullscreen : s.inline}
+      role="status"
+      aria-busy="true"
+    >
+      <div className={s.spinner} />
+      <p className={s.message}>{message}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
В этом PR реализована авторизация через OAuth2.0 (Google), а также вся сопутствующая логика:

Что сделано:
1) Создан AuthProvider, который управляет состоянием авторизации на клиенте
2) Изменено хук useOAuthLogin с поддержкой автоматического запроса getMe после OAuth-редиректа
3) Реализована логика AuthGuard — защита страниц, доступных только авторизованным пользователям
4) Обновлена логика baseQueryWithReauth — теперь при 401 автоматически отправляется запрос /auth/refresh-token с поддержкой mutex и cooldown
5) Улучшена обработка ошибок: сообщения могут приходить через query-параметры (например, ?error=email_exists) (Но на бэке пока не передается ошибка)
6) Обновлены компоненты OauthLoginSuccess, SocialLinks, добавлен loader и стили