### PR TITLE
fix: current subscription

### DIFF
--- a/src/features/profile/ui/management/subscriptionCard/SubscriptionCard.tsx
+++ b/src/features/profile/ui/management/subscriptionCard/SubscriptionCard.tsx
@@ -17,6 +17,12 @@ export const SubscriptionCard = ({ subscription, changeAccountType }: Props) => 
   const [cancelAutoRenewal] = useCancelAutoRenewalMutation()
   const [renewAutoRenewal] = useRenewAutoRenewalMutation()
 
+  const now = new Date()
+  const activeSubscriptions = subscription.data.filter(
+    ({ endDateOfSubscription }) => new Date(endDateOfSubscription) >= now
+  )
+  const lastActive = activeSubscriptions[activeSubscriptions.length - 1]
+
   const onCheckedChangeHandler = async () => {
     if (subscription.hasAutoRenewal) {
       try {
@@ -50,8 +56,8 @@ export const SubscriptionCard = ({ subscription, changeAccountType }: Props) => 
               Expire at
             </Typography>
 
-            {subscription.data.map(({ subscriptionId, endDateOfSubscription }) => (
-              <Typography className={s.value} variant="body2" fontWeight="bold" key={subscriptionId}>
+            {subscription.data.map(({ endDateOfSubscription }, index) => (
+              <Typography className={s.value} variant="body2" fontWeight="bold" key={index}>
                 {new Date(endDateOfSubscription).toLocaleDateString('pl-PL')}
               </Typography>
             ))}
@@ -62,11 +68,16 @@ export const SubscriptionCard = ({ subscription, changeAccountType }: Props) => 
               Next payment
             </Typography>
 
-            {subscription.data.map(({ subscriptionId, dateOfPayment }) => (
-              <Typography className={s.value} variant="body2" fontWeight="bold" key={subscriptionId}>
-                {new Date(dateOfPayment).toLocaleDateString('pl-PL')}
-              </Typography>
-            ))}
+            {subscription.hasAutoRenewal &&
+              subscription.data.map((_, index) => {
+                return (
+                  <Typography className={s.value} variant="body2" fontWeight="bold" key={index}>
+                    {new Date(
+                      new Date(lastActive.endDateOfSubscription).getTime() + 24 * 60 * 60 * 1000
+                    ).toLocaleDateString('pl-PL')}
+                  </Typography>
+                )
+              })}
           </div>
         </div>
       </Card>

--- a/src/features/profile/ui/management/subscriptionCard/SubscriptionCard.tsx
+++ b/src/features/profile/ui/management/subscriptionCard/SubscriptionCard.tsx
@@ -17,11 +17,7 @@ export const SubscriptionCard = ({ subscription, changeAccountType }: Props) => 
   const [cancelAutoRenewal] = useCancelAutoRenewalMutation()
   const [renewAutoRenewal] = useRenewAutoRenewalMutation()
 
-  const now = new Date()
-  const activeSubscriptions = subscription.data.filter(
-    ({ endDateOfSubscription }) => new Date(endDateOfSubscription) >= now
-  )
-  const lastActive = activeSubscriptions[activeSubscriptions.length - 1]
+  const lastActive = subscription.data[subscription.data.length - 1]
 
   const onCheckedChangeHandler = async () => {
     if (subscription.hasAutoRenewal) {
@@ -56,11 +52,9 @@ export const SubscriptionCard = ({ subscription, changeAccountType }: Props) => 
               Expire at
             </Typography>
 
-            {subscription.data.map(({ endDateOfSubscription }, index) => (
-              <Typography className={s.value} variant="body2" fontWeight="bold" key={index}>
-                {new Date(endDateOfSubscription).toLocaleDateString('pl-PL')}
-              </Typography>
-            ))}
+            <Typography className={s.value} variant="body2" fontWeight="bold">
+              {new Date(lastActive.endDateOfSubscription).toLocaleDateString('pl-PL')}
+            </Typography>
           </div>
 
           <div>
@@ -68,16 +62,13 @@ export const SubscriptionCard = ({ subscription, changeAccountType }: Props) => 
               Next payment
             </Typography>
 
-            {subscription.hasAutoRenewal &&
-              subscription.data.map((_, index) => {
-                return (
-                  <Typography className={s.value} variant="body2" fontWeight="bold" key={index}>
-                    {new Date(
-                      new Date(lastActive.endDateOfSubscription).getTime() + 24 * 60 * 60 * 1000
-                    ).toLocaleDateString('pl-PL')}
-                  </Typography>
-                )
-              })}
+            {subscription.hasAutoRenewal && (
+              <Typography className={s.value} variant="body2" fontWeight="bold">
+                {new Date(
+                  new Date(lastActive.endDateOfSubscription).getTime() + 24 * 60 * 60 * 1000
+                ).toLocaleDateString('pl-PL')}
+              </Typography>
+            )}
           </div>
         </div>
       </Card>


### PR DESCRIPTION
Исправлено отображение следующей даты оплаты подписки. Ранее отображались некорректные значения.

Теперь:
Дата следующей оплаты рассчитывается на основе последней активной подписки.
Дата отображается только если включен Auto-Renewal.
Если автообновление отключено, поле nextPayment не отображается вовсе.